### PR TITLE
Fixed lag issues when using the Inventory Access Port

### DIFF
--- a/src/main/java/com/hlysine/create_connected/content/inventoryaccessport/InventoryAccessPortBlock.java
+++ b/src/main/java/com/hlysine/create_connected/content/inventoryaccessport/InventoryAccessPortBlock.java
@@ -10,6 +10,7 @@ import net.minecraft.core.Direction.Axis;
 import net.minecraft.core.Vec3i;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -20,10 +21,11 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.common.extensions.IBlockExtension;
 import net.neoforged.neoforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 
-public class InventoryAccessPortBlock extends DirectedDirectionalBlock implements IBE<InventoryAccessPortBlockEntity>, IWrenchable {
+public class InventoryAccessPortBlock extends DirectedDirectionalBlock implements IBE<InventoryAccessPortBlockEntity>, IWrenchable, IBlockExtension {
 
     public static BooleanProperty ATTACHED = BlockStateProperties.ATTACHED;
 
@@ -73,15 +75,9 @@ public class InventoryAccessPortBlock extends DirectedDirectionalBlock implement
     }
 
     @Override
-    public void neighborChanged(@NotNull BlockState pState, @NotNull Level pLevel, @NotNull BlockPos pPos, @NotNull Block pBlock, @NotNull BlockPos pFromPos, boolean pIsMoving) {
-        withBlockEntityDo(pLevel, pPos, InventoryAccessPortBlockEntity::updateConnectedInventory);
-        super.neighborChanged(pState, pLevel, pPos, pBlock, pFromPos, pIsMoving);
-        Vec3i diff = pFromPos.subtract(pPos);
-        Direction fromSide = Direction.fromDelta(diff.getX(), diff.getY(), diff.getZ());
-        if (fromSide == null)
-            pLevel.updateNeighborsAt(pPos, this);
-        else
-            pLevel.updateNeighborsAtExceptFromFacing(pPos, this, fromSide);
+    public void onNeighborChange(@NotNull BlockState state, @NotNull LevelReader level, @NotNull BlockPos pos, @NotNull BlockPos neighbor) {
+        super.onNeighborChange(state, level, pos, neighbor);
+        withBlockEntityDo(level, pos, InventoryAccessPortBlockEntity::updateConnectedInventory);
     }
 
     @Override

--- a/src/main/java/com/hlysine/create_connected/content/inventoryaccessport/InventoryAccessPortBlockEntity.java
+++ b/src/main/java/com/hlysine/create_connected/content/inventoryaccessport/InventoryAccessPortBlockEntity.java
@@ -72,6 +72,7 @@ public class InventoryAccessPortBlockEntity extends SmartBlockEntity {
     public void updateConnectedInventory() {
         observedInventory.findNewCapability();
         boolean previouslyPowered = powered;
+        assert level != null;
         powered = level.hasNeighborSignal(worldPosition);
         if (powered != previouslyPowered) {
             notifyUpdate();


### PR DESCRIPTION
- Fixed lag spikes upon neighbor updates on the Inventory Access Port
- Fixed issue where Item Vaults will not cause for the Inventory Access Port to update upon auto-expanding them via placing them in front of the port