### PR TITLE
fix(dependency): update create dependency to 6.0.8-169, fixes #178

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,8 @@ parchment_minecraft_version=1.21.1
 
 create_minecraft_version = 1.21.1
 flywheel_minecraft_version = 1.21.1
-create_version = 6.0.7-117
-create_version_range = [6.0.7,)
+create_version = 6.0.8-169
+create_version_range = [6.0.8,)
 ponder_version = 1.0.63
 flywheel_version = 1.0.5
 registrate_version = MC1.21-1.3.0+62

--- a/src/main/java/com/hlysine/create_connected/config/CCConfigs.java
+++ b/src/main/java/com/hlysine/create_connected/config/CCConfigs.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 @SuppressWarnings("unused")
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, modid = CreateConnected.MODID)
+@EventBusSubscriber(modid = CreateConnected.MODID)
 public class CCConfigs {
 
     private static final Map<ModConfig.Type, ConfigBase> CONFIGS = new EnumMap<>(ModConfig.Type.class);

--- a/src/main/java/com/hlysine/create_connected/config/CCommon.java
+++ b/src/main/java/com/hlysine/create_connected/config/CCommon.java
@@ -1,19 +1,14 @@
 package com.hlysine.create_connected.config;
 
 import com.hlysine.create_connected.CreateConnected;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.configuration.ServerConfigurationPacketListener;
-import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.network.event.RegisterConfigurationTasksEvent;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import org.jetbrains.annotations.NotNull;
 
-@EventBusSubscriber(modid = CreateConnected.MODID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = CreateConnected.MODID)
 public class CCommon extends SyncConfigBase {
 
     @Override

--- a/src/main/java/com/hlysine/create_connected/content/copycat/WaterloggedCopycatWrappedBlock.java
+++ b/src/main/java/com/hlysine/create_connected/content/copycat/WaterloggedCopycatWrappedBlock.java
@@ -10,6 +10,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.neoforge.common.Tags;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class WaterloggedCopycatWrappedBlock extends MigratingWaterloggedCopycatBlock implements ICopycatWithWrappedBlock {
@@ -30,7 +31,7 @@ public abstract class WaterloggedCopycatWrappedBlock extends MigratingWaterlogge
     @Override
     protected @NotNull ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {
         ItemInteractionResult result = super.useItemOn(stack, state, level, pos, player, hand, hitResult);
-        if (!result.consumesAction() && !player.getItemInHand(hand).is(AllTags.AllItemTags.WRENCH.tag)) {
+        if (!result.consumesAction() && !player.getItemInHand(hand).is(Tags.Items.TOOLS_WRENCH)) {
             return ICopycatWithWrappedBlock.wrappedState(getWrappedBlock(), state).useItemOn(stack, level, player, hand, hitResult);
         }
         return result;

--- a/src/main/java/com/hlysine/create_connected/content/fluidvessel/FluidVesselBlockEntity.java
+++ b/src/main/java/com/hlysine/create_connected/content/fluidvessel/FluidVesselBlockEntity.java
@@ -36,7 +36,7 @@ import java.util.List;
 import static com.hlysine.create_connected.content.fluidvessel.FluidVesselBlock.*;
 import static net.minecraft.core.Direction.Axis;
 
-@EventBusSubscriber(modid = CreateConnected.MODID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = CreateConnected.MODID)
 public class FluidVesselBlockEntity extends FluidTankBlockEntity implements IHaveGoggleInformation, IMultiBlockEntityContainer.Fluid {
 
     private static final int MAX_SIZE = 3;

--- a/src/main/java/com/hlysine/create_connected/content/fluidvessel/FluidVesselMountedStorage.java
+++ b/src/main/java/com/hlysine/create_connected/content/fluidvessel/FluidVesselMountedStorage.java
@@ -67,7 +67,7 @@ public class FluidVesselMountedStorage extends WrapperMountedFluidStorage<FluidV
 
     @Override
     public void afterSync(Contraption contraption, BlockPos localPos) {
-        BlockEntity be = contraption.presentBlockEntities.get(localPos);
+        BlockEntity be = contraption.getBlockEntityClientSide(localPos);
         if (!(be instanceof FluidTankBlockEntity tank))
             return;
 

--- a/src/main/java/com/hlysine/create_connected/content/inventoryaccessport/InventoryAccessPortBlockEntity.java
+++ b/src/main/java/com/hlysine/create_connected/content/inventoryaccessport/InventoryAccessPortBlockEntity.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 
 import static com.hlysine.create_connected.content.inventoryaccessport.InventoryAccessPortBlock.ATTACHED;
 
-@EventBusSubscriber(modid = CreateConnected.MODID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = CreateConnected.MODID)
 public class InventoryAccessPortBlockEntity extends SmartBlockEntity {
     protected IItemHandler itemCapability;
     private InvManipulationBehaviour observedInventory;

--- a/src/main/java/com/hlysine/create_connected/content/inventorybridge/InventoryBridgeBlockEntity.java
+++ b/src/main/java/com/hlysine/create_connected/content/inventorybridge/InventoryBridgeBlockEntity.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 import static com.hlysine.create_connected.content.inventorybridge.InventoryBridgeBlock.ATTACHED_NEGATIVE;
 import static com.hlysine.create_connected.content.inventorybridge.InventoryBridgeBlock.ATTACHED_POSITIVE;
 
-@EventBusSubscriber(modid = CreateConnected.MODID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = CreateConnected.MODID)
 public class InventoryBridgeBlockEntity extends SmartBlockEntity {
     protected IItemHandler itemCapability;
     private InvManipulationBehaviour negativeInventory;

--- a/src/main/java/com/hlysine/create_connected/content/itemsilo/ItemSiloBlockEntity.java
+++ b/src/main/java/com/hlysine/create_connected/content/itemsilo/ItemSiloBlockEntity.java
@@ -34,7 +34,7 @@ import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
 
 import java.util.List;
 
-@EventBusSubscriber(modid = CreateConnected.MODID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = CreateConnected.MODID)
 public class ItemSiloBlockEntity extends SmartBlockEntity implements IMultiBlockEntityContainer.Inventory {
 
     protected ICapabilityProvider<IItemHandler> itemCapability = null;

--- a/src/main/java/com/hlysine/create_connected/datagen/recipes/CCStandardRecipes.java
+++ b/src/main/java/com/hlysine/create_connected/datagen/recipes/CCStandardRecipes.java
@@ -446,11 +446,12 @@ public class CCStandardRecipes extends BaseRecipeProvider {
                     .viaShapeless(b -> b
                             .requires(result)
                     );
+
         return create(result)
                 .unlockedBy(AllItems.ZINC_INGOT::get)
                 .requiresResultFeature()
                 .disabledInCopycats()
-                .viaStonecutting(Ingredient.of(AllTags.commonItemTag("ingots/zinc")), resultCount);
+                .viaStonecutting(Ingredient.of(TagKey.create(BuiltInRegistries.ITEM.key(), ResourceLocation.fromNamespaceAndPath("c", "ingots/zinc"))), resultCount);
     }
 
     protected static class Marker {

--- a/src/main/java/com/hlysine/create_connected/datagen/recipes/FillingRecipeGen.java
+++ b/src/main/java/com/hlysine/create_connected/datagen/recipes/FillingRecipeGen.java
@@ -4,8 +4,7 @@ import com.hlysine.create_connected.CCBlocks;
 import com.hlysine.create_connected.CCTags;
 import com.hlysine.create_connected.CreateConnected;
 import com.hlysine.create_connected.compat.Mods;
-import com.simibubi.create.AllRecipeTypes;
-import com.simibubi.create.foundation.fluid.FluidIngredient;
+import com.simibubi.create.foundation.fluid.FluidIngredientOld;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.world.level.material.Fluids;
@@ -26,7 +25,7 @@ public class FillingRecipeGen extends com.simibubi.create.api.data.recipe.Fillin
             .withCondition(new FeatureEnabledCondition(CCBlocks.EMPTY_FAN_CATALYST.getId()))
             .output(CCBlocks.FAN_SPLASHING_CATALYST));
 
-    GeneratedRecipe FAN_ENDING_CATALYST_DRAGONS_BREATH = create("fan_ending_catalyst_dragons_breath", b -> b.require(new FluidIngredient.FluidTagIngredient(CCTags.Fluids.FAN_PROCESSING_CATALYSTS_ENDING.tag, 1000))
+    GeneratedRecipe FAN_ENDING_CATALYST_DRAGONS_BREATH = create("fan_ending_catalyst_dragons_breath", b -> b.require(CCTags.Fluids.FAN_PROCESSING_CATALYSTS_ENDING.tag, 1000)
             .require(CCBlocks.EMPTY_FAN_CATALYST)
             .withCondition(new FeatureEnabledCondition(CCBlocks.EMPTY_FAN_CATALYST.getId()))
             .withCondition(new ModLoadedCondition(Mods.DRAGONS_PLUS.id()))


### PR DESCRIPTION
Hey! So as Create changed some internals and remove the WRENCH-Tag in AllItemTags, a modification is required to prevent the game from crashing when interacting with some copycat blocks. This fixes issue #178.