### PR TITLE
Fix linked transmitters deleting blocks

### DIFF
--- a/src/main/java/com/hlysine/create_connected/mixin/ItemUseOverridesMixin.java
+++ b/src/main/java/com/hlysine/create_connected/mixin/ItemUseOverridesMixin.java
@@ -5,6 +5,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.simibubi.create.foundation.block.ItemUseOverrides;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -29,10 +30,14 @@ public class ItemUseOverridesMixin {
                                                         BlockHitResult blockHitResult,
                                                         Operation<InteractionResult> original,
                                                         @Local ResourceLocation id) {
-        if (PreciseItemUseOverrides.OVERRIDES.contains(id)) {
-            HitResult hitResult = player.pick(player.blockInteractionRange(), 1, false);
-            if (hitResult instanceof BlockHitResult blockHit) {
-                return original.call(instance, level, player, interactionHand, blockHit);
+        // Raytracing here must only be done client-sided
+        // If it is done server-sided as well, an unexpected block may be selected because of de-synced rotation (#56)
+        if (player instanceof LocalPlayer) {
+            if (PreciseItemUseOverrides.OVERRIDES.contains(id)) {
+                HitResult hitResult = player.pick(player.blockInteractionRange(), 1, false);
+                if (hitResult instanceof BlockHitResult blockHit) {
+                    return original.call(instance, level, player, interactionHand, blockHit);
+                }
             }
         }
         return original.call(instance, level, player, interactionHand, blockHitResult);


### PR DESCRIPTION
## Description
Modified `ItemUseOverridesMixin.preciseHitLocation` so that it does not do raytracing server-sided, or else it may select an unexpected block because of de-synced rotation, which can be abused to break any blocks and duplicate linked transmitters.

## References
- Fixes #56
- Fixes #191 (duplicate of the issue above)
