### PR TITLE
Fix infinity multiplier on kinetic bridge by modifying NBT

### DIFF
--- a/src/main/java/com/hlysine/create_connected/content/kineticbridge/StressImpactScrollValueBehaviour.java
+++ b/src/main/java/com/hlysine/create_connected/content/kineticbridge/StressImpactScrollValueBehaviour.java
@@ -23,10 +23,12 @@ public class StressImpactScrollValueBehaviour extends ScrollValueBehaviour {
     }
 
     public static float convertValue(int value) {
-        if (value < 40) {
-            return (float) Math.pow(2, Math.abs(value / 10.0));
+        int absoluteValue = Math.abs(value);
+        double result = Math.pow(2, absoluteValue / 10.0);
+        if (absoluteValue < 40) {
+            return (float) result;
         } else {
-            return (int) Math.pow(2, Math.abs(value / 10.0));
+            return (int) result;
         }
     }
 


### PR DESCRIPTION
## Description
The modifier on a kinetic bridge could be modified to infinity by changing `ScrollValue` in its NBT to a negative number. This could be abused to make a network with NaN stress capacity that is able to power any machines. This pull request caps the multiplier to `Integer.MAX_VALUE` expected.

## References
- Fixes #193
