### PR TITLE
Fix kinetic battery output with zero battery level

### DIFF
--- a/src/main/java/com/hlysine/create_connected/content/kineticbattery/KineticBatteryBlockEntity.java
+++ b/src/main/java/com/hlysine/create_connected/content/kineticbattery/KineticBatteryBlockEntity.java
@@ -60,6 +60,7 @@ public class KineticBatteryBlockEntity extends GeneratingKineticBlockEntity impl
     @Override
     public void initialize() {
         super.initialize();
+        updateLevel();
         updateGeneratedRotation();
     }
 


### PR DESCRIPTION
## Description
A kinetic battery with zero battery level in NBT but non-zero battery level in block state could output rotational forces infinitely. This can be achieved in Survival by using schematics. This pull request adds a battery level update on block entity initialization so that the battery level in the block state is set to zero correctly on initialization.

## References
- Fixes #165
