### PR TITLE
Fix linked transmitter frequency not able to be set on server

### DIFF
--- a/src/main/java/com/hlysine/create_connected/mixin/ItemUseOverridesMixin.java
+++ b/src/main/java/com/hlysine/create_connected/mixin/ItemUseOverridesMixin.java
@@ -5,7 +5,6 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.simibubi.create.foundation.block.ItemUseOverrides;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -30,13 +29,13 @@ public class ItemUseOverridesMixin {
                                                         BlockHitResult blockHitResult,
                                                         Operation<InteractionResult> original,
                                                         @Local ResourceLocation id) {
-        // Raytracing here must only be done client-sided
-        // If it is done server-sided as well, an unexpected block may be selected because of de-synced rotation (#56)
-        if (level.isClientSide()) {
-            if (PreciseItemUseOverrides.OVERRIDES.contains(id)) {
-                HitResult hitResult = player.pick(player.blockInteractionRange(), 1, false);
-                if (hitResult instanceof BlockHitResult blockHit) {
-                    return original.call(instance, level, player, interactionHand, blockHit);
+        if (PreciseItemUseOverrides.OVERRIDES.contains(id)) {
+            HitResult preciseHitResult = player.pick(player.blockInteractionRange(), 1, false);
+            if (preciseHitResult instanceof BlockHitResult preciseBlockHitResult) {
+                // Ensures that preciseBlockHitResult has the same block pos as blockHitResult
+                // to prevent an unexpected block from being selected because of de-synced rotation (#56)
+                if (preciseBlockHitResult.getBlockPos().equals(blockHitResult.getBlockPos())) {
+                    return original.call(instance, level, player, interactionHand, preciseBlockHitResult);
                 }
             }
         }


### PR DESCRIPTION
## Description
Fixes the regression where the frequencies of a linked transmitter could not be set on server, caused by #199.

Sorry for the issue. Should have been more careful 😢
