### PR TITLE
Fix redstone link compat for VS2

### DIFF
--- a/src/main/java/com/hlysine/create_connected/mixin/redstonelinkwildcard/RedstoneLinkNetworkHandlerMixin.java
+++ b/src/main/java/com/hlysine/create_connected/mixin/redstonelinkwildcard/RedstoneLinkNetworkHandlerMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(RedstoneLinkNetworkHandler.class)
+@Mixin(value = RedstoneLinkNetworkHandler.class, priority = 2000)
 public class RedstoneLinkNetworkHandlerMixin {
     @Inject(
             method = "updateNetworkOf",


### PR DESCRIPTION
## Description
Valkyrien Skies 2 has a mixin that targets `RedstoneLinkNetworkHandler.updateNetworkOf` which is also targeted by a mixin in Create: Connected. The latter mixin cancels the original method, breaking the redstone link transmission between the ground and VS2 ships.

This pull request lowers the priority of `RedstoneLinkNetworkHandlerMixin` so that the injected method in VS2 is executed first before it would be cancelled by Create: Connected.

## References
- Fixes #182
  Duplicated by:
  - Fixes #194
  - Fixes #205