### PR TITLE
Enable Configuration Cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ processResources {
     inputs.properties replaceProperties
 
     filesMatching(['META-INF/neoforge.mods.toml', 'pack.mcmeta']) {
-        expand replaceProperties + [project: project]
+        expand replaceProperties
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'idea'
     id 'java-library'
     id 'maven-publish'
-    id 'net.neoforged.moddev' version '2.0.86'
+    id 'net.neoforged.moddev' version '2.0.141'
     id 'me.modmuss50.mod-publish-plugin' version '0.4.5'
 }
 
@@ -172,6 +172,13 @@ repositories {
     }
 }
 
+configurations {
+    localCompile
+    compileClasspath {
+        extendsFrom(localCompile)
+    }
+}
+
 dependencies {
     implementation "net.neoforged:neoforge:${neoforge_version}"
 
@@ -188,7 +195,7 @@ dependencies {
 //    implementation("maven.modrinth:create-garnished:${garnished_version}")
 //    runtimeOnly("maven.modrinth:create-dreams-and-desires:${dreams_desires_version}")
 //    runtimeOnly("plus.dragons.createdragonsplus:create-dragons-plus-${minecraft_version}:${create_dragons_plus_version}")
-    implementation("com.copycatsplus:copycats:${copycats_version}")
+    implementation("com.copycatsplus:copycats:${copycats_version}") { transitive = false }
     implementation("maven.modrinth:additional-placements:${additional_placements_version}")
 //    runtimeOnly("maven.modrinth:create-steam-n-rails:${steam_n_rails_version}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 
 ## Environment Properties
 

--- a/src/main/java/com/hlysine/create_connected/CreateConnectedClient.java
+++ b/src/main/java/com/hlysine/create_connected/CreateConnectedClient.java
@@ -5,15 +5,21 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.neoforged.neoforge.client.event.ModelEvent;
 
 @Mod(value = CreateConnected.MODID, dist = Dist.CLIENT)
 public class CreateConnectedClient {
     public CreateConnectedClient(IEventBus modEventBus) {
         CCPartialModels.register();
         modEventBus.addListener(CreateConnectedClient::init);
+        modEventBus.addListener(CreateConnectedClient::registerModelLoader);
     }
 
     public static void init(final FMLClientSetupEvent event) {
         PonderIndex.addPlugin(new CCPonderPlugin());
+    }
+
+    public static void registerModelLoader(ModelEvent.RegisterGeometryLoaders event) {
+        event.register(GatedModelLoader.ID, GatedModelLoader.INSTANCE);
     }
 }

--- a/src/main/java/com/hlysine/create_connected/GatedModelLoader.java
+++ b/src/main/java/com/hlysine/create_connected/GatedModelLoader.java
@@ -1,0 +1,75 @@
+package com.hlysine.create_connected;
+
+import com.google.common.collect.Maps;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.client.renderer.block.model.*;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.*;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.fml.ModList;
+import net.neoforged.neoforge.client.model.geometry.IGeometryBakingContext;
+import net.neoforged.neoforge.client.model.geometry.IGeometryLoader;
+import net.neoforged.neoforge.client.model.geometry.IUnbakedGeometry;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class GatedModelLoader implements IGeometryLoader<GatedModelLoader.BlockGeometry> {
+    public static final GatedModelLoader INSTANCE = new GatedModelLoader();
+    public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(CreateConnected.MODID, "gated_model_loader");
+
+    private GatedModelLoader() {}
+
+    @Override
+    public @NotNull BlockGeometry read(
+            JsonObject jsonObject,
+            @NotNull JsonDeserializationContext jsonDeserializationContext
+    ) throws JsonParseException {
+        JsonElement requiredId = jsonObject.get("required_modid");
+        String modId = null;
+        BlockModel model;
+
+        try {
+            modId = requiredId.getAsString();
+        } catch (NullPointerException | JsonParseException | IllegalStateException ignored) {}
+
+        if (modId == null || ModList.get().isLoaded(modId)) {
+            BlockModel.Deserializer blockReader = new BlockModel.Deserializer();
+            model = blockReader.deserialize(jsonObject, BlockModel.class, jsonDeserializationContext);
+        } else {
+            // fall back to empty model. same as air model.
+            model = new BlockModel(
+                    null,
+                    List.of(),
+                    Maps.newHashMap(),
+                    null,
+                    null,
+                    ItemTransforms.NO_TRANSFORMS, List.of()
+            );
+        }
+
+        return new BlockGeometry(model);
+    }
+
+    public static class BlockGeometry implements IUnbakedGeometry<BlockGeometry> {
+        final BlockModel blockModel;
+
+        public BlockGeometry(BlockModel blockModel) {
+            this.blockModel = blockModel;
+        }
+
+        @Override
+        public @NotNull BakedModel bake(IGeometryBakingContext iGeometryBakingContext, ModelBaker modelBaker, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ItemOverrides itemOverrides) {
+            return this.blockModel.bake(modelBaker, spriteGetter, modelState);
+        }
+
+        @Override
+        public void resolveParents(Function<ResourceLocation, UnbakedModel> modelGetter, IGeometryBakingContext context) {
+            this.blockModel.resolveParents(modelGetter);
+        }
+    }
+}

--- a/src/main/java/com/hlysine/create_connected/compat/ModMixin.java
+++ b/src/main/java/com/hlysine/create_connected/compat/ModMixin.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
  * Conditionally enable/disable a mixin based on the presence of other mods.
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 public @interface ModMixin {
     
     String[] mods();

--- a/src/main/java/com/hlysine/create_connected/mixin/MixinPlugin.java
+++ b/src/main/java/com/hlysine/create_connected/mixin/MixinPlugin.java
@@ -6,17 +6,20 @@ import net.neoforged.fml.loading.FMLLoader;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.asm.service.IClassBytecodeProvider;
 import org.spongepowered.asm.service.MixinService;
 import org.spongepowered.asm.util.Annotations;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 public class MixinPlugin implements IMixinConfigPlugin {
-    private boolean isFrameworkInstalled;
+    private boolean isFrameworkInstalled; // this makes sure that forge's helpful mods not found screen shows up
 
     @Override
     public void onLoad(String mixinPackage) {
@@ -36,23 +39,45 @@ public class MixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        try {
-            List<AnnotationNode> annotationNodes = MixinService.getService().getBytecodeProvider().getClassNode(mixinClassName).visibleAnnotations;
-            if (annotationNodes == null) return true;
+        String modMixin = Type.getDescriptor(ModMixin.class);
+        String pseudo = Type.getDescriptor(Pseudo.class);
+        IClassBytecodeProvider bytecodeProvider = MixinService.getService().getBytecodeProvider();
 
-            boolean shouldApply = true;
-            for (AnnotationNode node : annotationNodes) {
-                if (node.desc.equals(Type.getDescriptor(ModMixin.class))) {
-                    List<String> mods = Annotations.getValue(node, "mods", true);
-                    boolean applyIfPresent = Annotations.getValue(node, "applyIfPresent", Boolean.TRUE);
-                    boolean anyModsLoaded = anyModsLoaded(mods);
-                    shouldApply = anyModsLoaded == applyIfPresent;
-                }
-            }
-            return shouldApply;
+        ClassNode mixinClass;
+        ClassNode targetClass = null;
+        try {
+            mixinClass = bytecodeProvider.getClassNode(mixinClassName);
+        } catch (ClassNotFoundException | IOException ignored) {
+            return isFrameworkInstalled;
+        }
+        try {
+            targetClass = bytecodeProvider.getClassNode(targetClassName);
         } catch (ClassNotFoundException | IOException ignored) {
         }
-        return isFrameworkInstalled; // this makes sure that forge's helpful mods not found screen shows up
+
+        List<AnnotationNode> annotations = new ArrayList<>();
+        {
+            if (mixinClass.invisibleAnnotations != null) {
+                annotations.addAll(mixinClass.invisibleAnnotations);
+            }
+            if (mixinClass.visibleAnnotations != null) {
+                annotations.addAll(mixinClass.visibleAnnotations);
+            }
+        }
+
+        for (AnnotationNode node : annotations) {
+            if (node.desc.equals(modMixin)) {
+                List<String> mods = Annotations.getValue(node, "mods", true);
+                boolean applyIfPresent = Annotations.getValue(node, "applyIfPresent", Boolean.TRUE);
+                boolean anyModsLoaded = anyModsLoaded(mods);
+                return anyModsLoaded == applyIfPresent;
+            }
+
+            if (node.desc.equals(pseudo)) {
+                return targetClass != null;
+            }
+        }
+        return true;
     }
 
     private static boolean anyModsLoaded(List<String> mods) {

--- a/src/main/java/com/hlysine/create_connected/mixin/compat/CopycatBlockEntityMixin.java
+++ b/src/main/java/com/hlysine/create_connected/mixin/compat/CopycatBlockEntityMixin.java
@@ -1,6 +1,7 @@
 package com.hlysine.create_connected.mixin.compat;
 
 import com.hlysine.create_connected.compat.CopycatsManager;
+import com.hlysine.create_connected.compat.ModMixin;
 import com.hlysine.create_connected.compat.Mods;
 import com.hlysine.create_connected.config.CCConfigs;
 import com.simibubi.create.content.decoration.copycat.CopycatBlockEntity;
@@ -12,6 +13,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 
+@ModMixin(mods = {"copycats"})
 @Mixin(CopycatBlockEntity.class)
 public abstract class CopycatBlockEntityMixin extends SmartBlockEntity {
     public CopycatBlockEntityMixin(BlockEntityType<?> type, BlockPos pos, BlockState state) {

--- a/src/main/java/com/hlysine/create_connected/mixin/compat/CopycatBlockMixin.java
+++ b/src/main/java/com/hlysine/create_connected/mixin/compat/CopycatBlockMixin.java
@@ -3,12 +3,14 @@ package com.hlysine.create_connected.mixin.compat;
 import com.copycatsplus.copycats.content.copycat.board.CopycatBoardBlock;
 import com.copycatsplus.copycats.content.copycat.slab.CopycatSlabBlock;
 import com.hlysine.create_connected.compat.CopycatsManager;
+import com.hlysine.create_connected.compat.ModMixin;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+@ModMixin(mods = {"copycats"})
 @Mixin({CopycatSlabBlock.class, CopycatBoardBlock.class})
 public class CopycatBlockMixin {
     @Redirect(

--- a/src/main/java/com/hlysine/create_connected/mixin/nestedschematics/ClientSchematicLoaderMixin.java
+++ b/src/main/java/com/hlysine/create_connected/mixin/nestedschematics/ClientSchematicLoaderMixin.java
@@ -3,6 +3,7 @@ package com.hlysine.create_connected.mixin.nestedschematics;
 import com.hlysine.create_connected.config.CServer;
 import com.simibubi.create.content.schematics.client.ClientSchematicLoader;
 import net.minecraft.network.chat.Component;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -18,6 +19,7 @@ import java.util.List;
 
 @Mixin(value = ClientSchematicLoader.class, remap = false)
 public class ClientSchematicLoaderMixin {
+    @Final
     @Shadow
     private List<Component> availableSchematics;
 
@@ -31,11 +33,10 @@ public class ClientSchematicLoaderMixin {
 
     @Unique
     private void cc$searchInSubfolder(String folder, int depth) {
-        try {
-            boolean canRecurse = depth < CServer.SchematicsNestingDepth.get();
-            Path base = Path.of("schematics/");
-            Files.list(Path.of(folder))
-                    .forEach(path -> {
+        boolean canRecurse = depth < CServer.SchematicsNestingDepth.get();
+        Path base = Path.of("schematics/");
+        try(var files = Files.list(Path.of(folder))) {
+            files.forEach(path -> {
                         if (Files.isDirectory(path)) {
                             if (canRecurse && (depth != 0 || !path.getFileName().toString().equals("uploaded")))
                                 cc$searchInSubfolder(path.toString(), depth + 1);

--- a/src/main/java/com/hlysine/create_connected/mixin/sequencedgearshift/SequencedGearshiftScreenMixin.java
+++ b/src/main/java/com/hlysine/create_connected/mixin/sequencedgearshift/SequencedGearshiftScreenMixin.java
@@ -1,9 +1,12 @@
 package com.hlysine.create_connected.mixin.sequencedgearshift;
 
 import com.hlysine.create_connected.CCSequencerInstructions;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.simibubi.create.content.kinetics.transmission.sequencer.Instruction;
 import com.simibubi.create.content.kinetics.transmission.sequencer.SequencedGearshiftScreen;
 import com.simibubi.create.content.kinetics.transmission.sequencer.SequencerInstructions;
+import com.simibubi.create.foundation.blockEntity.behaviour.scrollValue.ScrollValueBehaviour;
 import com.simibubi.create.foundation.gui.widget.ScrollInput;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -12,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Vector;
+import java.util.function.Function;
 
 @Mixin(value = SequencedGearshiftScreen.class, remap = false)
 public class SequencedGearshiftScreenMixin {
@@ -20,16 +24,16 @@ public class SequencedGearshiftScreenMixin {
     @Shadow
     private Vector<Vector<ScrollInput>> inputs;
 
-    @Inject(
+    @WrapOperation(
             method = "updateParamsOfRow(I)V",
             at = @At(
                     value = "INVOKE",
-                    target = "Lcom/simibubi/create/foundation/gui/widget/ScrollInput;standardStep()Ljava/util/function/Function;",
-                    shift = At.Shift.BY,
-                    by = 2
+                    target = "Lcom/simibubi/create/foundation/gui/widget/ScrollInput;withStepFunction(Ljava/util/function/Function;)Lcom/simibubi/create/foundation/gui/widget/ScrollInput;",
+                    ordinal = 1
             )
     )
-    public void updateParamsOfRow(int row, CallbackInfo ci) {
+    public ScrollInput updateParamsOfRow(ScrollInput instance, Function<ScrollValueBehaviour.StepContext, Integer> step, Operation<ScrollInput> original, int row) {
+        ScrollInput toReturn = original.call(instance, step);
         if (((InstructionAccessor) instructions.get(row)).getInstruction() == CCSequencerInstructions.TURN_TIME) {
             Vector<ScrollInput> rowInputs = inputs.get(row);
             ScrollInput value = rowInputs.get(1);
@@ -42,6 +46,7 @@ public class SequencedGearshiftScreenMixin {
                 return context.shift ? 100 : 20;
             });
         }
+        return toReturn;
     }
 
     @Inject(

--- a/src/main/resources/assets/create_connected/models/block/fan_ending_catalyst_dragons_breath/block.json
+++ b/src/main/resources/assets/create_connected/models/block/fan_ending_catalyst_dragons_breath/block.json
@@ -1,4 +1,6 @@
 {
+	"loader": "create_connected:gated_model_loader",
+	"required_modid": "create_dragons_plus",
 	"credit": "Made with Blockbench",
 	"parent": "minecraft:block/block",
 	"textures": {

--- a/src/main/resources/assets/create_connected/models/block/fan_enriched_catalyst/block.json
+++ b/src/main/resources/assets/create_connected/models/block/fan_enriched_catalyst/block.json
@@ -1,4 +1,6 @@
 {
+	"loader": "create_connected:gated_model_loader",
+	"required_modid": "createnuclear",
 	"credit": "Made with Blockbench",
 	"parent": "minecraft:block/block",
 	"textures": {


### PR DESCRIPTION
I was trying to include create connected using composite build and found out that Configuration Cache is explicitly disabled. and I fixed error that arised when I enabled it back. I am sending this PR in case the error is the only reason why is it disabled.

To explain why it failed, this part of the code:
```gradle
    filesMatching(['META-INF/neoforge.mods.toml', 'pack.mcmeta']) {
        expand replaceProperties + [project: project]
    }
```
uses object `project` to replace "${project}" in those files. but I don't see mention of word `project` in both toml and mcmeta files. so it can be removed.