### PR TITLE
Disable transitive dependencies of copycats+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'idea'
     id 'java-library'
     id 'maven-publish'
-    id 'net.neoforged.moddev' version '2.0.86'
+    id 'net.neoforged.moddev' version '2.0.141'
     id 'me.modmuss50.mod-publish-plugin' version '0.4.5'
 }
 
@@ -172,6 +172,13 @@ repositories {
     }
 }
 
+configurations {
+    localCompile
+    compileClasspath {
+        extendsFrom(localCompile)
+    }
+}
+
 dependencies {
     implementation "net.neoforged:neoforge:${neoforge_version}"
 
@@ -188,7 +195,7 @@ dependencies {
 //    implementation("maven.modrinth:create-garnished:${garnished_version}")
 //    runtimeOnly("maven.modrinth:create-dreams-and-desires:${dreams_desires_version}")
 //    runtimeOnly("plus.dragons.createdragonsplus:create-dragons-plus-${minecraft_version}:${create_dragons_plus_version}")
-    implementation("com.copycatsplus:copycats:${copycats_version}")
+    implementation("com.copycatsplus:copycats:${copycats_version}") { transitive = false }
     implementation("maven.modrinth:additional-placements:${additional_placements_version}")
 //    runtimeOnly("maven.modrinth:create-steam-n-rails:${steam_n_rails_version}")
 


### PR DESCRIPTION
This PR disabled transitive dependencies on CopyCats+
Previously, runtimeClasspath was like this:
<img width="453" height="245" alt="image" src="https://github.com/user-attachments/assets/1c363f94-b784-4438-833d-407e4c05d9ec" />

You can see one of them is Athena mod from Curseforge. so it was downloading it regardless it's used or not.

Now, runtimeClasspath is like this:
<img width="453" height="151" alt="image" src="https://github.com/user-attachments/assets/d9e9db16-5336-4566-9143-5a43ad454d61" />

This was causing trouble for me when I included this project using `includeBuild`.
When I include "Create: Connected", it added Create's transitive dependencies as well through CopyCats+.