### PR TITLE
Enable Configuration Cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ processResources {
     inputs.properties replaceProperties
 
     filesMatching(['META-INF/neoforge.mods.toml', 'pack.mcmeta']) {
-        expand replaceProperties + [project: project]
+        expand replaceProperties
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 
 ## Environment Properties
 


### PR DESCRIPTION
This PR enables Configuration Cache that was explicitly disabled. I assume reason for it is it throws error when it's enabled.
To explain why it throws error, this part of the code:
```gradle
    filesMatching(['META-INF/neoforge.mods.toml', 'pack.mcmeta']) {
        expand replaceProperties + [project: project]
    }
```
uses object `project` to replace "${project}" in those files. but I don't see mention of word `project` in both toml and mcmeta files. so it can be removed.