### PR TITLE
fix: instant dead battery & min discharge not working.

### DIFF
--- a/src/main/java/com/hlysine/create_connected/content/kineticbattery/KineticBatteryBlockEntity.java
+++ b/src/main/java/com/hlysine/create_connected/content/kineticbattery/KineticBatteryBlockEntity.java
@@ -94,7 +94,7 @@ public class KineticBatteryBlockEntity extends GeneratingKineticBlockEntity impl
             return;
         boolean changed = false;
         if (isDischarging(getBlockState())) {
-            if (batteryLevel > 0 && stress > 0) {
+            if (batteryLevel > 0) {
                 if (lastCapacityProvided == 0) {
                     calculateAddedStressCapacity();
                 }

--- a/src/main/java/com/hlysine/create_connected/content/kineticbattery/KineticBatteryBlockEntity.java
+++ b/src/main/java/com/hlysine/create_connected/content/kineticbattery/KineticBatteryBlockEntity.java
@@ -98,7 +98,7 @@ public class KineticBatteryBlockEntity extends GeneratingKineticBlockEntity impl
                 if (lastCapacityProvided == 0) {
                     calculateAddedStressCapacity();
                 }
-                batteryLevel = Math.min(Math.max(batteryLevel - lastCapacityProvided * Math.abs(getGeneratedSpeed()), 0), CServer.BatteryMinDischarge.get());
+                batteryLevel = Math.max(batteryLevel - Math.max(lastCapacityProvided * Math.abs(getGeneratedSpeed()), CServer.BatteryMinDischarge.get()), 0);
                 changed = true;
             }
         } else {


### PR DESCRIPTION
fixes #241 
So the latest version of c:c just broke the battery because it instantly discharges. And also the feature that was implemented didn't actually work because `stress` was `0`.